### PR TITLE
demux_mkv: copy attachments (fonts) from ordered chapter sources

### DIFF
--- a/demux/demux_mkv_timeline.c
+++ b/demux/demux_mkv_timeline.c
@@ -305,6 +305,16 @@ static void find_ordered_chapter_sources(struct tl_ctx *ctx)
         ctx->num_sources = j;
     }
 
+    // Copy attachments from referenced sources so fonts are loaded for sub
+    // rendering.
+    for (int i = 1; i < ctx->num_sources; i++) {
+        for (int j = 0; j < ctx->sources[i]->num_attachments; j++) {
+            struct demux_attachment *att = &ctx->sources[i]->attachments[j];
+            demuxer_add_attachment(ctx->demuxer, att->name, att->type,
+                                   att->data, att->data_size);
+        }
+    }
+
     talloc_free(tmp);
 }
 


### PR DESCRIPTION
They might be needed for rendering subs from those sources.

Fixes #6009.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
