### PR TITLE
demux_edl: add title option to override title of chapters

### DIFF
--- a/DOCS/edl-mpv.rst
+++ b/DOCS/edl-mpv.rst
@@ -147,6 +147,24 @@ Example::
 
 Plays chapter 3 and ends with the start of chapter 7 (4 chapters later).
 
+Implicit chapters
+=================
+
+mpv will add one chapter per segment entry to the virtual timeline.
+
+By default, the chapter's titles will match the entries' filenames.
+You can override set the ``title`` option to override the chapter title for
+that segment.
+
+Example::
+
+    # mpv EDL v0
+    cap.ts,5,240
+    OP.mkv,0,90,title=Show Opening
+
+The virtual timeline will have two chapters, one called "cap.ts" from 0-240s
+and a second one called "Show Opening" from 240-330s.
+
 Syntax of EDL URIs
 ==================
 

--- a/demux/demux_edl.c
+++ b/demux/demux_edl.c
@@ -41,6 +41,7 @@ struct tl_part {
     bool offset_set;
     bool chapter_ts;
     double length;              // length of the part (-1 if rest of the file)
+    char *title;
 };
 
 struct tl_parts {
@@ -123,6 +124,8 @@ static struct tl_parts *parse_edl(bstr str)
             } else if (bstr_equals0(name, "timestamps")) {
                 if (bstr_equals0(val, "chapters"))
                     p.chapter_ts = true;
+            } else if (bstr_equals0(name, "title")) {
+                p.title = bstrto0(tl, val);
             }
             if (nparam >= MAX_PARAMS)
                 goto error;
@@ -296,7 +299,7 @@ static void build_timeline(struct timeline *tl, struct tl_parts *parts)
                 .pts = starttime,
                 .metadata = talloc_zero(tl, struct mp_tags),
             };
-            mp_tags_set_str(ch.metadata, "title", part->filename);
+            mp_tags_set_str(ch.metadata, "title", part->title ? part->title : part->filename);
             MP_TARRAY_APPEND(tl, tl->chapters, tl->num_chapters, ch);
 
             // Also copy the source file's chapters for the relevant parts


### PR DESCRIPTION
Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
